### PR TITLE
Fix custom due date visibility on edit

### DIFF
--- a/components/ActionTracker.jsx
+++ b/components/ActionTracker.jsx
@@ -108,6 +108,12 @@ const ActionTracker = () => {
     setFormData(action);
     setEditingAction(action);
     setShowForm(true);
+    // Show the custom date input when the existing due date does not match
+    // one of the predefined quick select options
+    const isCustom =
+      action.dueDate &&
+      !dueDateOptions.some((option) => option.value === action.dueDate);
+    setShowCustomDate(isCustom);
   };
 
   const handleStatusChange = async (actionId, newStatus) => {


### PR DESCRIPTION
## Summary
- show custom date field when editing an action with a non-standard due date

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cecf25fec83329e4649119df49b58